### PR TITLE
Use sort by start/end to make traversing of who's oncall easier

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,25 @@ Then add **hubot-pager-me** to your `external-scripts.json`:
 | `HUBOT_PAGERDUTY_SERVICES` | No | Provide a comma separated list of service identifiers (e.g. `PFGPBFY,AFBCGH`) to restrict queries to only those services. |
 | `HUBOT_PAGERDUTY_TEAMS` | No | Provide a comma separated list of teams identifiers (e.g. `PFGPBFY,AFBCGH`) to restrict queries to only those teams. You need teams function on |
 | `HUBOT_PAGERDUTY_SCHEDULES` | No | Provide a comma separated list of schedules identifiers (e.g. `PFGPBFY,AFBCGH`) to restrict queries to only those schedules. |
+| `HUBOT_PAGERDUTY_SCHEDULE_USERSUP_ID` | No`*` | UserSupport Schedule identifier (e.g. `PQZRDUG`) used when looking for User Support shifts |
+| `HUBOT_PAGERDUTY_SCHEDULE_PLATFORM_ID` | No`*` | PlatformOncall-L1 Schedule identifier (e.g. `PQZRDUG`) used when looking for Platform OnCall shifts |
+| `HUBOT_PAGERDUTY_SCHEDULE_ESCALATION_ID` | No`*` | IncidentCommand-L2 Schedule identifier (e.g. `PQZRDUG`) used when looking for Incident Command shifts |
 
 `*` - May be required for certain actions.
+
+## Run locally to query PagerDuty API for OnCall shifts
+
+**Note**: Requires all three `HUBOT_PAGERDUTY_SCHEDULE_<...>_ID` environment variables to be set.
+
+After installing all the `node_modules`, and exporting neccessary environment variables you can run the script and pass it a message as a command (it will print-back the output):
+
+```
+node ./node_modules/.bin/coffee index.coffee "who's oncall"
+
+node ./node_modules/.bin/coffee index.coffee "who's oncall next"
+
+node ./node_modules/.bin/coffee index.coffee "who was oncall"
+```
 
 ### Webhook
 

--- a/index.coffee
+++ b/index.coffee
@@ -10,3 +10,60 @@ module.exports = (robot, scripts) ->
           robot.loadFile(scriptsPath, script) if script in scripts
         else
           robot.loadFile(scriptsPath, script)
+
+if require.main == module
+  console.log('Hubot Pager Me Loaded as primary module')
+
+  # a dummy robot that can not do much
+  robot = {
+    functions: []
+    send: (txt) ->
+      console.log('Hubot answer:')
+      console.log(txt)
+      return
+  }
+
+  pagerduty = require('./src/pagerduty')
+  if pagerduty.missingEnvironmentForApi(robot)
+    return
+
+  robot.receive = (msg) ->
+    res = null
+    filtered = robot.functions.filter((setup) ->
+      temp = msg.match(setup.regex)
+      if temp != null
+        res = temp
+        return true
+    )
+    if res != null
+      console.log('Found a message match!')
+    return { filtered, res }
+
+  robot.respond = (regex, fn) ->
+    robot.functions.push({ regex, fn })
+    return
+
+  robot.loadFile = (pathToScript, scriptFileName) ->
+    resolvedPathToScript = path.join(pathToScript, scriptFileName)
+    fn = require(resolvedPathToScript)
+    fn(robot)
+    return
+
+
+  inp = process.argv[process.argv.length - 1]
+
+  setTimeout(() ->
+    # load the hubot scripts
+    module.exports(robot)
+    return
+  , 10)
+  setTimeout(() ->
+    # run a custom message parsing
+    parsed = robot.receive(if (inp.indexOf('coffee') > -1) then "who's oncall" else inp)
+    if parsed.res == null
+      console.log('No match')
+    else
+      command = parsed.filtered[0]
+      command.fn(robot)
+    return
+  , 500)

--- a/src/pagerduty.coffee
+++ b/src/pagerduty.coffee
@@ -153,8 +153,6 @@ module.exports =
     if pagerDutyEscalationsPolicies?
       query['escalation_policy_ids[]'] = pagerDutyEscalationsPolicies.split(',')
 
-    console.error query
-
     @get "/oncalls", query, (err, json) ->
       if err?
         cb(err)

--- a/src/scripts/pagerduty-custom.coffee
+++ b/src/scripts/pagerduty-custom.coffee
@@ -46,7 +46,7 @@ findIncidentCmd = (oncalls, timeFrame, now) ->
     ))
 
   if timeFrame is 'next'
-    found = first(oncalls.find((oncall) ->
+    found = first(oncalls.filter((oncall) ->
       oncall.start < nowPlus24h
     ))
 

--- a/src/scripts/pagerduty-custom.coffee
+++ b/src/scripts/pagerduty-custom.coffee
@@ -1,5 +1,5 @@
 pagerduty = require('../pagerduty')
-pick = require('lodash/pick')
+{ first, last, pick } = require('lodash')
 
 userSupportId = process.env.HUBOT_PAGERDUTY_SCHEDULE_USERSUP_ID
 platformId = process.env.HUBOT_PAGERDUTY_SCHEDULE_PLATFORM_ID
@@ -17,14 +17,14 @@ filterIncidentCmd = (oncall) -> oncall.schedule.id is escalationId
 findOncall = (oncalls, timeFrame, now) ->
   nowIso = new Date(now).toISOString()
   if timeFrame in ['was', 'before']
-    return oncalls.filter((oncall) ->
+    return last(oncalls.filter((oncall) ->
       oncall.end < nowIso
-    ).slice(-1)[0] # last end before now
+    )) # last oncall.end before now
 
   if timeFrame in ['next', 'after']
-    return oncalls.filter((oncall) ->
+    return first(oncalls.filter((oncall) ->
       oncall.start > nowIso
-    ).slice(0, 1)[0] # first start after now
+    )) # first oncall.start after now
 
   return oncalls.find((oncall) ->
     oncall.start < nowIso < oncall.end
@@ -41,14 +41,14 @@ findIncidentCmd = (oncalls, timeFrame, now) ->
   nowPlus24h = new Date(now + oneDayMs).toISOString()
 
   if timeFrame is 'was'
-    found = oncalls.find((oncall) ->
+    found = last(oncalls.filter((oncall) ->
       oncall.end > nowMinus24h
-    )
+    ))
 
   if timeFrame is 'next'
-    found = oncalls.find((oncall) ->
+    found = first(oncalls.find((oncall) ->
       oncall.start < nowPlus24h
-    )
+    ))
 
   return found || findOncall(oncalls, 'now', now)
 

--- a/src/scripts/pagerduty.coffee
+++ b/src/scripts/pagerduty.coffee
@@ -610,6 +610,14 @@ module.exports = (robot) ->
   robot.respond /who(?:’s|'s|s| is|se)? ((next (on call|oncall|on-call))|((on call|oncall|on-call) next))/i, (msg) ->
     getCustomOncalls 'next', msg
 
+  # who is on call after current shift?
+  robot.respond /who(?:’s|'s|s| is|se)? ((after (on call|oncall|on-call))|((on call|oncall|on-call) after))/i, (msg) ->
+    getCustomOncalls 'after', msg
+
+  # who is on call after current shift?
+  robot.respond /who(?:’s|'s|s| is|se)? ((before (on call|oncall|on-call))|((on call|oncall|on-call) before))/i, (msg) ->
+    getCustomOncalls 'before', msg
+
   # who is on call?
   robot.respond /who(?:’s|'s|s| is|se)? (?:on call|oncall|on-call)(?:\?)?(?: (?:for )?((["'])([^]*?)\2|(.*?))(?:\?|$))?$/i, (msg) ->
     getCustomOncalls 'now', msg

--- a/src/scripts/pagerduty.coffee
+++ b/src/scripts/pagerduty.coffee
@@ -614,8 +614,8 @@ module.exports = (robot) ->
   robot.respond /who(?:’s|'s|s| is|se)? ((after (on call|oncall|on-call))|((on call|oncall|on-call) after))/i, (msg) ->
     getCustomOncalls 'after', msg
 
-  # who is on call after current shift?
-  robot.respond /who(?:’s|'s|s| is|se)? ((before (on call|oncall|on-call))|((on call|oncall|on-call) before))/i, (msg) ->
+  # who was on call before current shift?
+  robot.respond /who(?:’s|'s|s| is| was|se)? ((before (on call|oncall|on-call))|((on call|oncall|on-call) before))/i, (msg) ->
     getCustomOncalls 'before', msg
 
   # who is on call?

--- a/test/pagerduty-custom-unit.coffee
+++ b/test/pagerduty-custom-unit.coffee
@@ -1,15 +1,17 @@
-# module.exports = { findOncall, formatTime }
 chai = require 'chai'
-formatTime = require('../src/scripts/pagerduty-custom.coffee').formatTime
-findOncall = require('../src/scripts/pagerduty-custom.coffee').findOncall
-setTimeQuery = require('../src/scripts/pagerduty-custom.coffee').setTimeQuery
+
+{
+  formatTime
+  findOncall
+  setTimeQuery
+} = require('../src/scripts/pagerduty-custom.coffee')
 
 expect = chai.expect
 
 oncalls = [
-  {name: 'yesterday', start: "2020-11-27T17:00:00.000Z", end: "2020-11-29T17:00:00.000Z"},
-  {name: 'today',start: "2020-11-29T17:00:00.000Z", end: "2020-11-30T17:00:00.000Z"},
-  {name: 'tomorrow',start: "2020-11-30T17:00:00.000Z", end: "2020-12-01T17:00:00.000Z"},
+  { name: 'yesterday', start: "2020-11-27T17:00:00.000Z", end: "2020-11-29T17:00:00.000Z" },
+  { name: 'today', start: "2020-11-29T17:00:00.000Z", end: "2020-11-30T17:00:00.000Z" },
+  { name: 'tomorrow',start: "2020-11-30T17:00:00.000Z", end: "2020-12-01T17:00:00.000Z" },
 ]
 
 timeNow = Date.parse("2020-11-30T13:00:00.000Z")
@@ -21,15 +23,21 @@ describe 'custom on call - findOncall', ->
   it 'should return yesterday for `was` timeFrame', ->
     expect(findOncall(oncalls, 'was', timeNow).name).to.equal('yesterday')
 
-  it 'should return yesterday for `next` timeFrame', ->
+  it 'should return yesterday for `before` timeFrame', ->
+    expect(findOncall(oncalls, 'before', timeNow).name).to.equal('yesterday')
+
+  it 'should return tomorrow for `next` timeFrame', ->
     expect(findOncall(oncalls, 'next', timeNow).name).to.equal('tomorrow')
+
+  it 'should return tomorrow for `after` timeFrame', ->
+    expect(findOncall(oncalls, 'after', timeNow).name).to.equal('tomorrow')
 
 describe 'custom on call - formatTime', ->
   it 'should format time correctly', ->
     expect(formatTime(oncalls[1].start)).to.equal('Sun Nov 29 18:00')
     expect(formatTime(oncalls[0].end)).to.equal('Sun Nov 29 18:00')
     expect(formatTime(oncalls[2].end)).to.equal('Tue Dec 01 18:00')
-  
+
 describe 'custom on call - setTimeQuery', ->
   it 'should return time query according to requested time', ->
     expect(setTimeQuery('now', timeNow).since).to.equal('2020-11-30T13:00:00.000Z')


### PR DESCRIPTION
- introduces `who's oncall after`
- introduces `who's oncall before`
- uses sorted list of oncall shifts so it can be traversed for first (starts after now) or last (ends before now) shifts
- also allows for local running via `node ./node_modules/.bin/coffee index.coffee "who's oncall"`